### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #   WeirDOM - main generator script
 #   -------------------------------
 #
@@ -307,7 +308,7 @@ def CheckGrammar(grammar):
       tagname = part['tagname']
       #print tagname
       if not tagname in grammar._creators:
-        print 'No creators for type ' + tagname
+        print('No creators for type ' + tagname)
 
 def GenerateNewSample(template, htmlgrammar, cssgrammar, jsgrammar):
   """Parses grammar rules from string.
@@ -361,21 +362,21 @@ def GenerateSamples(grammar_dir, outfiles):
   err = htmlgrammar.ParseFromFile(os.path.join(grammar_dir, 'html.txt'))
   #CheckGrammar(htmlgrammar)
   if err > 0:
-    print 'There were errors parsing grammar'
+    print('There were errors parsing grammar')
     return
 
   cssgrammar = Grammar()
   err = cssgrammar.ParseFromFile(os.path.join(grammar_dir, 'css.txt'))
   #CheckGrammar(cssgrammar)
   if err > 0:
-    print 'There were errors parsing grammar'
+    print('There were errors parsing grammar')
     return
 
   jsgrammar = Grammar()
   err = jsgrammar.ParseFromFile(os.path.join(grammar_dir, 'js.txt'))
   #CheckGrammar(jsgrammar)
   if err > 0:
-    print 'There were errors parsing grammar'
+    print('There were errors parsing grammar')
     return
 
   # JS and HTML grammar need acces to CSS grammar.
@@ -387,13 +388,13 @@ def GenerateSamples(grammar_dir, outfiles):
     result = GenerateNewSample(template, htmlgrammar, cssgrammar, jsgrammar)
 
     if result is not None:
-      print 'Writing a sample to ' + outfile
+      print('Writing a sample to ' + outfile)
       try:
         f = open(outfile, 'w')
         f.write(result)
         f.close()
       except IOError:
-        print 'Error writing to output'
+        print('Error writing to output')
 
 def getOption(option_name):
   for i in range(len(sys.argv)):
@@ -415,11 +416,11 @@ def main():
     multiple_samples = True    
 
   if multiple_samples:
-    print 'Running on ClusterFuzz'
+    print('Running on ClusterFuzz')
     out_dir = getOption('--output_dir')
     nsamples = int(getOption('--no_of_files'))
-    print 'Output directory: ' + out_dir
-    print 'Number of samples: ' + str(nsamples)
+    print('Output directory: ' + out_dir)
+    print('Number of samples: ' + str(nsamples))
 
     outfiles = []
     for i in range(nsamples):
@@ -432,7 +433,7 @@ def main():
     GenerateSamples(fuzzer_dir, [outfile])
 
   else:
-    print 'Arguments missing'
+    print('Arguments missing')
 
 if __name__ == '__main__':
   main()

--- a/grammar.py
+++ b/grammar.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #   WeirDOM - grammar parser and generator
 #   --------------------------------------
 #
@@ -264,8 +265,8 @@ class Grammar(object):
         creator = self._creators['line'][lineno]
         self._ExpandRule('line', creator, tmp_context, 0, False)
         context = tmp_context
-      except RecursionError, e:
-        print 'Warning: ' + str(e)
+      except RecursionError as e:
+        print('Warning: ' + str(e))
     for i in range(len(context['lines'])/100):
       context['lines'].insert(random.randint(0,len(context['lines'])), 'freememory();')
     if not self._line_guard:
@@ -285,7 +286,7 @@ class Grammar(object):
     # pylint: disable=exec-used
     try:
       exec(compiled_function, args)
-    except Exception, e:
+    except Exception as e:
       raise GrammarError('Error in user-defined function: %s' % str(e))
     return args['ret_val']
 
@@ -443,7 +444,7 @@ class Grammar(object):
         try:
           expanded = self._Generate(part['tagname'], context,
                                     recursion_depth + 1, force_nonrecursive)
-        except RecursionError, e:
+        except RecursionError as e:
           if not force_nonrecursive:
             expanded = self._Generate(part['tagname'], context,
                                       recursion_depth + 1, True)
@@ -487,7 +488,7 @@ class Grammar(object):
       context = {'lastvar': 0, 'lines': [], 'variables': {}, 'force_var_reuse': False}
       return self._Generate(self._root, context, 0)
     else:
-      print 'Error: No root element defined.'
+      print('Error: No root element defined.')
       return ''
 
   def GenerateSymbol(self, name):
@@ -723,7 +724,7 @@ class Grammar(object):
     source = self._FixIdents(source)
     try:
       compiled_fn = compile(source, name, 'exec')
-    except (SyntaxError, TypeError), e:
+    except (SyntaxError, TypeError) as e:
       raise GrammarError('Error in user-defined function: %s' % str(e))
     self._functions[name] = compiled_fn
 
@@ -822,14 +823,14 @@ class Grammar(object):
             function_body = ''
             in_function = True
           else:
-            print 'Error parsing line ' + line
+            print('Error parsing line ' + line)
             num_errors += 1
         elif command == 'end' and params == 'function':
           if in_function:
             in_function = False
             self._SaveFunction(function_name, function_body)
         else:
-          print 'Unknown command: ' + command
+          print('Unknown command: ' + command)
           num_errors += 1
         continue
 
@@ -841,7 +842,7 @@ class Grammar(object):
         else:
           self._ParseGrammarLine(cleanline)
       except GrammarError:
-        print 'Error parsing line ' + line
+        print('Error parsing line ' + line)
         num_errors += 1
 
     return num_errors
@@ -852,7 +853,7 @@ class Grammar(object):
       content = f.read()
       f.close()
     except IOError:
-      print 'Error reading ' + filename
+      print('Error reading ' + filename)
       return 1
     self._definitions_dir = os.path.dirname(filename)
     return self.ParseFromString(content)
@@ -896,7 +897,7 @@ class Grammar(object):
       content = f.read()
       f.close()
     except IOError:
-      print 'Error reading ' + filename
+      print('Error reading ' + filename)
       return 1
     self._definitions_dir = os.path.dirname(filename)
     return self.ParseFromString(content)


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _probably_ be more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`