### PR TITLE
Make it compatible with python2 and 3

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -264,7 +264,7 @@ _SVG_TYPES = {
 
 def generate_html_elements(ctx, n):
     for i in range(n):
-        tag = random.choice(list(_HTML_TYPES.keys()))
+        tag = random.choice(list(_HTML_TYPES))
         tagtype = _HTML_TYPES[tag]
         ctx['htmlvarctr'] += 1
         varname = 'htmlvar%05d' % ctx['htmlvarctr']

--- a/generator.py
+++ b/generator.py
@@ -264,7 +264,7 @@ _SVG_TYPES = {
 
 def generate_html_elements(ctx, n):
     for i in range(n):
-        tag = random.choice(_HTML_TYPES.keys())
+        tag = random.choice(list(_HTML_TYPES.keys()))
         tagtype = _HTML_TYPES[tag]
         ctx['htmlvarctr'] += 1
         varname = 'htmlvar%05d' % ctx['htmlvarctr']

--- a/generator.py
+++ b/generator.py
@@ -438,6 +438,7 @@ def main():
     for a in sys.argv:
         if a.startswith('--output_dir='):
             multiple_samples = True
+
     if '--output_dir' in sys.argv:
         multiple_samples = True
 
@@ -447,6 +448,9 @@ def main():
         nsamples = int(get_option('--no_of_files'))
         print('Output directory: ' + out_dir)
         print('Number of samples: ' + str(nsamples))
+
+        if not os.path.exists(out_dir):
+            os.mkdir(out_dir)
 
         outfiles = []
         for i in range(nsamples):
@@ -460,6 +464,9 @@ def main():
 
     else:
         print('Arguments missing')
+        print("Usage:")
+        print("\tpython generator.py <output file>")
+        print("\tpython generator.py --output_dir <output directory> --no_of_files <number of output files>")
 
 
 if __name__ == '__main__':

--- a/grammar.py
+++ b/grammar.py
@@ -292,7 +292,7 @@ class Grammar(object):
                 context = tmp_context
             except RecursionError as e:
                 print('Warning: ' + str(e))
-        for i in range(int(len(context['lines']) / 100)):
+        for i in range(len(context['lines']) // 100):
             context['lines'].insert(
                 random.randint(0, len(context['lines'])),
                 'freememory();'

--- a/grammar.py
+++ b/grammar.py
@@ -292,7 +292,7 @@ class Grammar(object):
                 context = tmp_context
             except RecursionError as e:
                 print('Warning: ' + str(e))
-        for i in range(len(context['lines']) / 100):
+        for i in range(int(len(context['lines']) / 100)):
             context['lines'].insert(
                 random.randint(0, len(context['lines'])),
                 'freememory();'
@@ -633,11 +633,11 @@ class Grammar(object):
         preprocessing function that makes subsequent creator selection
         based on probability easier.
         """
-        for symbol, creators in self._creators.iteritems():
+        for symbol, creators in self._creators.items():
             cdf = self._get_cdf(symbol, creators)
             self._creator_cdfs[symbol] = cdf
 
-        for symbol, creators in self._nonrecursive_creators.iteritems():
+        for symbol, creators in self._nonrecursive_creators.items():
             cdf = self._get_cdf(symbol, creators)
             self._nonrecursivecreator_cdfs[symbol] = cdf
 


### PR DESCRIPTION
Make the some changes to convert the repo's code to be compatible with both Python 2 and Python 3. 

- ``iteritems => items`` Python3's dict does not have iteritems method, but both Python2 and Python3's dict have items method, so I change this one.
- ``_HTML_TYPES.keys() => list(_HTML_TYPES)`` Python3 'dict_keys' object does not support indexing

Apart from this, maybe add some help message and auto make dir for output dir will be better?

